### PR TITLE
bypass subscribe limits in /admin/pds/requestCrawl

### DIFF
--- a/cmd/relay/handlers.go
+++ b/cmd/relay/handlers.go
@@ -65,7 +65,7 @@ func (s *Service) handleComAtprotoSyncRequestCrawl(c echo.Context, body *comatpr
 	}
 	go s.ForwardSiblingRequest(c, b)
 
-	return s.relay.SubscribeToHost(ctx, hostname, noSSL, false)
+	return s.relay.SubscribeToHost(ctx, hostname, noSSL, admin)
 }
 
 func (s *Service) handleComAtprotoSyncListHosts(c echo.Context, cursor int64, limit int) (*comatproto.SyncListHosts_Output, error) {


### PR DESCRIPTION
`handleComAtprotoSyncRequestCrawl` should pass its boolean `admin` flag to `SubscribeToHost`, to let it bypass the daily new host limit when run as admin. Currently it just always passes `false`. The result is that when calling `goat relay admin host add` or the `/admin/pds/requestCrawl` endpoint, you get a "500 new host subscriptions temporarily disabled" error in response.
